### PR TITLE
Legg til apper for henting og lagring av selvbestemt IM i dev og prod

### DIFF
--- a/topics/dev/im-rapid.yaml
+++ b/topics/dev/im-rapid.yaml
@@ -75,6 +75,12 @@ spec:
       application: im-innsending
       access: readwrite
     - team: helsearbeidsgiver
+      application: im-selvbestemt-hent-im-service
+      access: readwrite
+    - team: helsearbeidsgiver
+      application: im-selvbestemt-lagre-im-service
+      access: readwrite
+    - team: helsearbeidsgiver
       application: im-tilgangservice
       access: readwrite
     - team: helsearbeidsgiver

--- a/topics/prod/im-rapid.yaml
+++ b/topics/prod/im-rapid.yaml
@@ -72,6 +72,12 @@ spec:
       application: im-innsending
       access: readwrite
     - team: helsearbeidsgiver
+      application: im-selvbestemt-hent-im-service
+      access: readwrite
+    - team: helsearbeidsgiver
+      application: im-selvbestemt-lagre-im-service
+      access: readwrite
+    - team: helsearbeidsgiver
       application: im-tilgangservice
       access: readwrite
     - team: helsearbeidsgiver


### PR DESCRIPTION
De to nye erstatter `im-aapenimservice`, som kun ligger i dev i dag. Lager en egen PR for å fjerne den.