### PR TITLE
Lag ny topic for dialoger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         topic: [
           api-innsending,
+          dialog,
           im-rapid,
           inntektsmelding-ekstern,
           inntektsmelding-topic,

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         topic: [
           api-innsending,
+          dialog,
           im-rapid,
           inntektsmelding-ekstern,
           inntektsmelding-topic,

--- a/topics/dev/dialog.yaml
+++ b/topics/dev/dialog.yaml
@@ -25,4 +25,4 @@ spec:
       access: readwrite
     - team: helsearbeidsgiver
       application: dialog
-      access: readwrite
+      access: read

--- a/topics/dev/dialog.yaml
+++ b/topics/dev/dialog.yaml
@@ -1,0 +1,28 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: dialog
+  namespace: helsearbeidsgiver
+  labels:
+    team: helsearbeidsgiver
+  annotations:
+    dcat.data.nav.no/title: "Dialog"
+    dcat.data.nav.no/description: "Sykmeldinger, søknader og forespørsler om inntektsmeldinger som skal sendes til arbeidsgiver gjennom Dialogporten"
+    dcat.data.nav.no/keyword: "sykepenger, arbeidsgiver, dialogporten"
+    dcat.data.nav.no/theme: "sykepenger"
+
+spec:
+  pool: nav-dev
+  config: # optional; all fields are optional too; defaults shown
+    minimumInSyncReplicas: 1
+    partitions: 3
+    replication: 2  # see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 1  # -1 means unlimited
+  acl:
+    - team: helsearbeidsgiver
+      application: sykepenger-im-lps-api
+      access: readwrite
+    - team: helsearbeidsgiver
+      application: dialog
+      access: readwrite

--- a/topics/prod/dialog.yaml
+++ b/topics/prod/dialog.yaml
@@ -26,4 +26,3 @@ spec:
     - team: helsearbeidsgiver
       application: dialog
       access: read
-

--- a/topics/prod/dialog.yaml
+++ b/topics/prod/dialog.yaml
@@ -25,5 +25,5 @@ spec:
       access: readwrite
     - team: helsearbeidsgiver
       application: dialog
-      access: readwrite
+      access: read
 

--- a/topics/prod/dialog.yaml
+++ b/topics/prod/dialog.yaml
@@ -1,0 +1,29 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: dialog
+  namespace: helsearbeidsgiver
+  labels:
+    team: helsearbeidsgiver
+  annotations:
+    dcat.data.nav.no/title: "Dialog"
+    dcat.data.nav.no/description: "Sykmeldinger, søknader og forespørsler om inntektsmeldinger som skal sendes til arbeidsgiver gjennom Dialogporten"
+    dcat.data.nav.no/keyword: "sykepenger, arbeidsgiver, dialogporten"
+    dcat.data.nav.no/theme: "sykepenger"
+
+spec:
+  pool: nav-prod
+  config:  # optional; all fields are optional too; defaults shown
+    minimumInSyncReplicas: 1
+    partitions: 3
+    replication: 2  # see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 168  # -1 means unlimited
+  acl:
+    - team: helsearbeidsgiver
+      application: sykepenger-im-lps-api
+      access: readwrite
+    - team: helsearbeidsgiver
+      application: dialog
+      access: readwrite
+


### PR DESCRIPTION
**Bakgrunn**
Vi skal skille ut Dialogporten-håndteringen vår i en egen app (fra LPS-API-appen) og ønsker et nytt topic for å kunne sende meldinger til denne nye Dialog-appen om hvilke dialoger den skal opprette og oppdatere i Dialogporten.

**Løsning**
Opprett nytt topic med navn `dialog` i dev og prod.